### PR TITLE
ci: run on main branch push instead of PR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,20 +1,20 @@
 name: Release
 
 on:
-  pull_request:
-    branches: [ main ]
+  push:
+    branches:
+      - main
 
 jobs:
   release:
     runs-on: ubuntu-latest
-    outputs:
-      new-release-version: ${{ steps.dry-release.outputs.new-release-version }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          ref: ${{ github.head_ref }}
+          ref: ${{ github.event.pull_request.base.ref }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -32,17 +32,9 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-node-
 
-      - name: Create release
-        id: dry-release
-        run: |
-          OUTPUT="$(bash -c "unset GITHUB_ACTIONS && npx semantic-release --dry-run --debug --no-ci --branches '${HEAD_REF}'")"
-          NEW_RELEASE_VERSION=$(echo "$OUTPUT" | grep -oP 'The next release version is \K(\d+\.\d+\.\d+)')
-          echo "new-release-version=$NEW_RELEASE_VERSION" >> "$GITHUB_OUTPUT"
+      - name: Run semantic release
+        run: npx semantic release
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
-          HEAD_REF: ${{ github.head_ref }}
-
-      - name: Echo new release version
-        run: echo "New release version is ${{ steps.dry-release.outputs.new-release-version }}"
     permissions:
       contents: write


### PR DESCRIPTION
## **Type**
enhancement


___

## **Description**
- Changed the CI trigger from pull request to push on the main branch, allowing the workflow to run on direct pushes to main.
- Simplified the release process by removing the dry-run steps and directly running semantic release.
- Adjusted the checkout step to use the base ref of the pull request event, ensuring the correct codebase is checked out for the release.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ci.yml</strong><dd><code>Simplify CI Workflow and Change Trigger to Push on Main Branch</code></dd></summary>
<hr>
      
.github/workflows/ci.yml

<li>Changed trigger from pull request to push on the main branch.<br> <li> Removed steps related to dry-release and its outputs.<br> <li> Simplified the release process to directly run semantic release.<br> <li> Adjusted the checkout step to use the base ref of the pull request <br>event.<br>


</details>
    

  </td>
  <td><a href="https://github.com/spencerjstewart/practical-javascript/pull/9/files#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03f">+7/-15</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

